### PR TITLE
allow users to specify agp workspace from an env variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 ## Building
 
 To build the agp-experimental/declarative, you need to also have Android Studio codebase checked out
-and pointed to by the WORKSPACE_LOCATION environment variable. It is needed to access some of the testing
+and pointed to by the AGP_WORKSPACE_LOCATION environment variable. It is needed to access some of the testing
 infrastructure like accessing SDK, NDK and services like exploring APKs, AARs, etc...
 You also need to have the CUSTOM_REPO environment variable set. 
 
 So for example this is what I use on my mac
 ```
-WORKSPACE_LOCATION=/Users/jedo/src/studio-main
-CUSTOM_REPO=$WORKSPACE_LOCATION/out/repo:$WORKSPACE_LOCATION/prebuilts/tools/common/m2/repository
+AGP_WORKSPACE_LOCATION=/Users/jedo/src/studio-main
+CUSTOM_REPO=$AGP_WORKSPACE_LOCATION/out/repo:$AGP_WORKSPACE_LOCATION/prebuilts/tools/common/m2/repository
 ```
 
 To build : `gw publish`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 tasks.test {
 	this.environment("CUSTOM_REPO", System.getenv("CUSTOM_REPO") + File.pathSeparatorChar + "${project.rootDir}/out/repo")
 	this.environment("TEST_TMPDIR", project.buildDir)
-	this.environment("WORKSPACE_LOCATION", providers.gradleProperty("com.android.workspace.location").get())
+	this.environment("AGP_WORKSPACE_LOCATION", providers.gradleProperty("com.android.workspace.location").get())
 	this.environment("PLUGIN_VERSION", Constants.PLUGIN_VERSION)
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,12 +15,15 @@ include("tests")
 // related to test project building and APK files exploration.
 // Therefore, one must define the "com.android.workspace.location" property to point to the location of the
 // studio-main workspace.
-val workspaceLocationProperty = providers.gradleProperty("com.android.workspace.location")
-if (!workspaceLocationProperty.isPresent) {
-    throw java.lang.IllegalArgumentException(
-        "com.android.workspace.location Gradle property must point to your checked out studio-main workspace")
+val agpWorkspaceLocationProperty = providers.gradleProperty("com.android.workspace.location")
+val agpWorkspaceLocation  = if (agpWorkspaceLocationProperty.isPresent) {
+    agpWorkspaceLocationProperty.get()
+} else {
+    System.getenv("WORKSPACE_LOCATION") ?:
+        throw java.lang.IllegalArgumentException(
+            "com.android.workspace.location Gradle property must point to your checked out studio-main workspace"
+        )
 }
-val workspaceLocation = workspaceLocationProperty.get()
 
 // Provide the maven repositories to find all binaries and built dependencies.
 if (System.getenv("CUSTOM_REPO") != null) {
@@ -33,13 +36,16 @@ if (System.getenv("CUSTOM_REPO") != null) {
 } else {
     // no environment variable, revert to hardcoded versions from the workspace location
     dependencyResolutionManagement.repositories {
-        maven { url = java.net.URI("file://$workspaceLocation/out/repo") }
-        maven { url = java.net.URI("file://$workspaceLocation/prebuilts/tools/common/m2/repository") }
+        maven { url = java.net.URI("file://$agpWorkspaceLocation/out/repo") }
+        maven { url = java.net.URI("file://$agpWorkspaceLocation/prebuilts/tools/common/m2/repository") }
     }
 }
 
 // any tests module automatically on published plugins
 settings.gradle.beforeProject {
+    extra.apply {
+        set("agpWorkspace", agpWorkspaceLocation)
+    }
     if (path.contains("tests")) {
         this.afterEvaluate {
             this.getTasksByName("test", false).forEach {
@@ -50,7 +56,7 @@ settings.gradle.beforeProject {
 }
 
 // Include the studio-main build to retrieve the integration-test framework dependency that 'tests' project is using.
-includeBuild("$workspaceLocation/tools") {
+includeBuild("$agpWorkspaceLocation/tools") {
     dependencySubstitution {
         substitute(module("com.android.build.integration-test:framework")).using(project(":base:build-system:integration-test:framework"))
         substitute(module("com.android.tools.build.declarative:model")).using(project(":base:declarative-gradle:model"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ val agpWorkspaceLocationProperty = providers.gradleProperty("com.android.workspa
 val agpWorkspaceLocation  = if (agpWorkspaceLocationProperty.isPresent) {
     agpWorkspaceLocationProperty.get()
 } else {
-    System.getenv("WORKSPACE_LOCATION") ?:
+    System.getenv("AGP_WORKSPACE_LOCATION") ?:
         throw java.lang.IllegalArgumentException(
             "com.android.workspace.location Gradle property must point to your checked out studio-main workspace"
         )

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.extra
+
 /*
  * Copyright (C) 2023 The Android Open Source Project
  *
@@ -18,10 +20,12 @@ plugins {
 	alias(libs.plugins.kotlin.jvm)
 }
 
+val agpWorkspace = extra.get("agpWorkspace")
+
 tasks.test {
 	this.environment("CUSTOM_REPO", System.getenv("CUSTOM_REPO") + File.pathSeparatorChar + "${project.rootDir}/out/repo")
 	this.environment("TEST_TMPDIR", project.buildDir)
-	this.environment("WORKSPACE_LOCATION", providers.gradleProperty("com.android.workspace.location").get())
+	this.environment("WORKSPACE_LOCATION", agpWorkspace)
 	this.environment("PLUGIN_VERSION", Constants.PLUGIN_VERSION)
 }
 

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -25,7 +25,7 @@ val agpWorkspace = extra.get("agpWorkspace")
 tasks.test {
 	this.environment("CUSTOM_REPO", System.getenv("CUSTOM_REPO") + File.pathSeparatorChar + "${project.rootDir}/out/repo")
 	this.environment("TEST_TMPDIR", project.buildDir)
-	this.environment("WORKSPACE_LOCATION", agpWorkspace)
+	this.environment("AGP_WORKSPACE_LOCATION", agpWorkspace)
 	this.environment("PLUGIN_VERSION", Constants.PLUGIN_VERSION)
 }
 


### PR DESCRIPTION
it makes it easier than always relying on a gradle property.