### PR TITLE
Make plugins compatible with configuration cache.

### DIFF
--- a/impl/src/main/kotlin/com/android/declarative/internal/AbstractDeclarativePlugin.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/AbstractDeclarativePlugin.kt
@@ -29,6 +29,16 @@ abstract class AbstractDeclarativePlugin {
 
     abstract val buildFileName: String
 
+    internal fun parseDeclarativeFile(
+        location: String,
+        declarativeFileContent: String,
+        issueLogger: IssueLogger,
+    ): TomlParseResult =
+        DeclarativeFileParser(issueLogger).parseDeclarativeFile(
+            location,
+            declarativeFileContent,
+        )
+
     internal fun parseDeclarativeInFolder(folder: File, issueLogger: IssueLogger): TomlParseResult =
         parseDeclarativeFile(Paths.get(folder.absolutePath, buildFileName), issueLogger)
 

--- a/impl/src/main/kotlin/com/android/declarative/internal/DeclarativeFileValueSource.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/DeclarativeFileValueSource.kt
@@ -1,0 +1,74 @@
+package com.android.declarative.internal
+
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.initialization.Settings
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+
+/**
+ * Implementation of [ValueSource] for declarative files that are accessed/read during configuration
+ * time.
+ */
+abstract class DeclarativeFileValueSource : ValueSource<String?, DeclarativeFileValueSource.Params> {
+
+    companion object {
+
+        /**
+         * Enlists a new file to be monitored for configuration cache invalidation.
+         * @param providers [ProviderFactory] to create instances of [DeclarativeFileValueSource]
+         * @param file the [File] to monitor.
+         */
+        fun enlist(
+            providers: ProviderFactory,
+            file: RegularFile,
+        ): Provider<String?> =
+            providers.of(DeclarativeFileValueSource::class.java) {
+                it.parameters.configFile.set(file)
+            }
+
+        /**
+         * Enlists a new file to be monitored for configuration cache invalidation.
+         * @param providers [ProviderFactory] to create instances of [DeclarativeFileValueSource]
+         * @param file the [Provider] of [RegularFile] to monitor.
+         */
+        fun enlist(
+            providers: ProviderFactory,
+            file: Provider<RegularFile>,
+        ): Provider<String?> =
+            providers.of(DeclarativeFileValueSource::class.java) {
+                it.parameters.configFile.set(file)
+            }
+
+        /**
+         * Enlists a new file to be monitored for configuration cache invalidation.
+         * @param objects [ObjectFactory] to create instances of [DirectoryProprty]
+         * @param settings [Settings] instance
+         * @param fileName file name for a file present or not in [Settings.getSettingsDir]
+         */
+        fun enlist(
+            objects: ObjectFactory,
+            settings: Settings,
+            fileName: String,
+        ): Provider<String?> =
+            enlist(settings.providers,
+                objects.directoryProperty().also {
+                    it.set(settings.settingsDir)
+                }.file(fileName)
+            )
+    }
+
+    interface Params : ValueSourceParameters {
+        val configFile: RegularFileProperty
+    }
+
+    /**
+     * Return the file content or null if the file does not exists.
+     */
+    override fun obtain(): String? {
+        return parameters.configFile.asFile.get().takeIf { it.exists() }?.bufferedReader()?.readText()
+    }
+}

--- a/impl/src/test/kotlin/com/android/declarative/internal/DependencyProcessorTest.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/DependencyProcessorTest.kt
@@ -16,11 +16,10 @@
 
 package com.android.declarative.internal
 
-import com.android.declarative.internal.model.DependencyInfo
-import com.android.declarative.internal.model.DependencyInfo.FilesDependencyInfo
-import com.android.declarative.internal.model.DependencyInfo.MavenDependencyInfo
-import com.android.declarative.internal.model.DependencyInfo.NotationDependencyInfo
 import com.android.declarative.internal.model.DependencyType
+import com.android.declarative.internal.model.FilesDependencyInfo
+import com.android.declarative.internal.model.MavenDependencyInfo
+import com.android.declarative.internal.model.NotationDependencyInfo
 import com.android.utils.ILogger
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ExternalModuleDependency
@@ -29,7 +28,6 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.dsl.DependencyFactory
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.logging.Logger
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/tests/src/test/kotlin/com/android/declarative/infra/DeclarativeTestProjectBuilder.kt
+++ b/tests/src/test/kotlin/com/android/declarative/infra/DeclarativeTestProjectBuilder.kt
@@ -34,7 +34,7 @@ class DeclarativeTestProjectBuilder {
             ?: throw RuntimeException("Cannot locate test directories")
         // now go up until I find the project root folder
         var path : Path? = thisClass.toURI().toPath()
-        while(path != null && path.name != "declarative-gradle") {
+        while(path != null && path.name != "gradle-declarative") {
             path = path.parent
         }
         return path?.resolve("tests/src/test-projects")


### PR DESCRIPTION
The declarative plugins are reading declarative files during configuration and these file access need to be registered to the configuration cache runtime for proper invalidation of the caches.

Test: Existing.
Bug: N/A