### PR TITLE
initial implementation of variant API access declaratively.

### DIFF
--- a/impl/build.gradle.kts
+++ b/impl/build.gradle.kts
@@ -33,9 +33,9 @@ dependencies {
 	implementation(libs.coroutines)
 	implementation(libs.toolsCommon)
 	implementation(libs.declarativeModel)
+	implementation(libs.agpApi)
 
 	testImplementation(libs.junit)
 	testImplementation(libs.mockito)
-	testImplementation(libs.agpApi)
 	testImplementation(libs.truth)
 }

--- a/impl/src/main/kotlin/com/android/declarative/internal/DeclarativeFileParser.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/DeclarativeFileParser.kt
@@ -1,0 +1,12 @@
+package com.android.declarative.internal
+
+import org.tomlj.TomlTable
+import kotlin.reflect.KClass
+
+interface DeclarativeFileParser {
+
+    /**
+     * parse a [TomlTable] into an extension object of type [T]
+     */
+    fun <T : Any> parse(table: TomlTable, type: KClass<out T>, extension: T)
+}

--- a/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
@@ -16,15 +16,15 @@
 
 package com.android.declarative.internal
 
-import com.android.declarative.internal.IssueLogger
-import com.android.declarative.internal.toml.forEachTable
 import com.android.declarative.internal.parsers.DependencyParser
 import com.android.declarative.internal.parsers.PluginParser
 import com.android.declarative.internal.tasks.DeclarativeBuildSerializerTask
+import com.android.declarative.internal.variantApi.AndroidComponentsParser
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.tomlj.TomlParseResult
 import org.gradle.internal.time.Time
+import org.tomlj.TomlTable
 import java.io.File
 import javax.inject.Inject
 
@@ -72,30 +72,32 @@ class DeclarativePlugin @Inject constructor(
                 "dependencies" -> {
                     // handled below, so all DSL driven configurations are created before dependencies are added.
                 }
-                else -> {
-                    if (!parsedDecl.isTable(topLevelDeclaration)) {
-                        throw Error("Invalid declaration, $topLevelDeclaration must be a TOML table")
-                    }
-                    // find the extension registered under the name
-                    val publicExtensionType = project.extensions.extensionsSchema.first {
-                        it.name == topLevelDeclaration
-                    }.publicType
+                "androidComponents" -> {
+                    // androidComponents is handled separately with a dedicated parser since it is very
+                    // heavy on callbacks which cannot be generically parsed.
 
-                    issueLogger.logger.LOG { "Extension type is $publicExtensionType" }
-                    project.extensions.findByName(topLevelDeclaration)?.also { extension ->
-                        GenericDeclarativeParser(project, issueLogger).parse(
-                            parsedDecl.getTable(topLevelDeclaration)
-                                ?: throw Error("Internal error : please file a bug providing your TOML file"),
-                            publicExtensionType.concreteClass.kotlin,
-                            extension
-                        )
-                    } ?: throw Error("Cannot find extension $topLevelDeclaration, " +
-                            "has the plugin registering the extension been applied ?")
+                    parseTomlTable(
+                        AndroidComponentsParser(project, issueLogger),
+                        topLevelDeclaration,
+                        parsedDecl,
+                        project,
+                        issueLogger
+                    )
+                }
+                else -> {
+                    parseTomlTable(
+                        GenericDeclarativeParser(project, issueLogger),
+                        topLevelDeclaration,
+                        parsedDecl,
+                        project,
+                        issueLogger
+                    )
                 }
             }
         }
 
         parsedDecl.getTable("dependencies")?.also {
+            @Suppress("UnstableApiUsage")
             DependencyProcessor(
                 { projectPath: String -> project.rootProject.project(projectPath)},
                 project::files,
@@ -120,5 +122,41 @@ class DeclarativePlugin @Inject constructor(
                 it.extension.set(android)
             }
         }
+    }
+
+    /**
+     * Parse a [TomlTable] using a dedicated [DeclarativeFileParser].
+     *
+     * @param parser the Toml parser for this Toml declaration
+     * @param topLevelDeclaration name of the top level extension block, like 'android' or 'androidComponents`
+     * @param parsedToml the [TomlTable] to parse
+     * @param project the project being configured
+     * @param issueLogger to log issues and traces
+     */
+    private fun parseTomlTable(
+        parser: DeclarativeFileParser,
+        topLevelDeclaration: String,
+        parsedToml: TomlTable,
+        project: Project,
+        issueLogger: IssueLogger
+    ) {
+        if (!parsedToml.isTable(topLevelDeclaration)) {
+            throw Error("Invalid declaration, $topLevelDeclaration must be a TOML table")
+        }
+        // find the extension registered under the name
+        val publicExtensionType = project.extensions.extensionsSchema.first {
+            it.name == topLevelDeclaration
+        }.publicType
+
+        issueLogger.logger.LOG { "Extension type is $publicExtensionType" }
+        project.extensions.findByName(topLevelDeclaration)?.also { extension ->
+            parser.parse(
+                parsedToml.getTable(topLevelDeclaration)
+                    ?: throw Error("Internal error : please file a bug providing your TOML file"),
+                publicExtensionType.concreteClass.kotlin,
+                publicExtensionType.concreteClass.cast(extension)
+            )
+        } ?: throw Error("Cannot find extension $topLevelDeclaration, " +
+                "has the plugin registering the extension been applied ?")
     }
 }

--- a/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
@@ -141,7 +141,8 @@ class DeclarativePlugin @Inject constructor(
         issueLogger: IssueLogger
     ) {
         if (!parsedToml.isTable(topLevelDeclaration)) {
-            throw Error("Invalid declaration, $topLevelDeclaration must be a TOML table")
+            issueLogger.logger.warning("Invalid declaration, $topLevelDeclaration must be a TOML table")
+            return
         }
         // find the extension registered under the name
         val publicExtensionType = project.extensions.extensionsSchema.first {

--- a/impl/src/main/kotlin/com/android/declarative/internal/DslTypesCache.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/DslTypesCache.kt
@@ -22,7 +22,7 @@ import kotlin.reflect.KClass
 /**
  * Maintains all the [DslTypeResult] for already visited DSL types.
  */
-class DslTypesCache {
+class DslTypesCache() {
 
     val cache = mutableListOf<DslTypeResult<*>>()
 

--- a/impl/src/main/kotlin/com/android/declarative/internal/GenericDeclarativeParser.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/GenericDeclarativeParser.kt
@@ -16,6 +16,7 @@
 
 package com.android.declarative.internal
 
+import com.android.build.api.variant.AndroidComponentsExtension
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.provider.Property

--- a/impl/src/main/kotlin/com/android/declarative/internal/SettingsDeclarativePlugin.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/SettingsDeclarativePlugin.kt
@@ -267,7 +267,7 @@ class SettingsDeclarativePlugin @Inject constructor(
                                 it.set(settings.settingsDir)
                             }
                             val buildDir = objects.directoryProperty().also {
-                                it.set(settingsDir.dir(relativePath))
+                                it.set(settingsDir.dir(relativePath.substring(1)))
                             }
 
                             val declarativeFileContent = DeclarativeFileValueSource.enlist(
@@ -275,11 +275,8 @@ class SettingsDeclarativePlugin @Inject constructor(
                                 buildDir.file(buildFileName),
                             )
 
-                            val fileContents = settings.providers.fileContents(
-                                settingsDir.dir(relativePath).get().file(relativePath)
-                            )
-                            if (fileContents.asText.isPresent) {
-                                fileContents.asText.get()
+                            if (declarativeFileContent.isPresent) {
+                                declarativeFileContent.get()
                             } else null
                         },
                         settingsDeclarations,

--- a/impl/src/main/kotlin/com/android/declarative/internal/tasks/DeclarativeBuildSerializerTask.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/tasks/DeclarativeBuildSerializerTask.kt
@@ -21,9 +21,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
-import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
-import kotlin.reflect.javaType
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.jvmErasure
 

--- a/impl/src/main/kotlin/com/android/declarative/internal/variantApi/AndroidComponentsParser.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/variantApi/AndroidComponentsParser.kt
@@ -1,0 +1,108 @@
+package com.android.declarative.internal.variantApi
+
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.Variant
+import com.android.build.api.variant.VariantBuilder
+import com.android.build.api.variant.VariantSelector
+import com.android.declarative.internal.DeclarativeFileParser
+import com.android.declarative.internal.GenericDeclarativeParser
+import com.android.declarative.internal.IssueLogger
+import com.android.declarative.internal.LoggerWrapper
+import org.gradle.api.Project
+import org.tomlj.TomlTable
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * Specialized parser responsible for parsing the 'androidComponents' elements
+ * in declarative file.
+ */
+class AndroidComponentsParser(
+    private val project: Project,
+    private val issueLogger: IssueLogger =
+        IssueLogger(false, LoggerWrapper(project.logger)),
+): DeclarativeFileParser {
+
+    override fun <T: Any> parse(table: TomlTable, type: KClass<out T>, extension: T) {
+        // the extension is a subclass of AndroidComponentsExtension, its type parameters will tell me
+        // type types of the VariantBuilder and Variant object I am dealing with.
+        val superType = type.supertypes.first { superType ->
+            superType.jvmErasure.simpleName == "AndroidComponentsExtension"
+        }
+
+        // now the superType arguments are as follows
+        // superType.arguments[0] is the DSL common extension type
+        // superType.arguments[1] is the VariantBuilder type
+        // superType.arguments[2] is the Variant type.
+        val variantBuilderType = superType.arguments[1].type
+            ?: throw RuntimeException("Cannot determine the VariantBuilder type for extension $type")
+
+        val variantType = superType.arguments[2].type
+            ?: throw RuntimeException("Cannot determine the Variant type for extension $type")
+
+        // It is not necessary to cast to the AndroidComponentsExtension subtype as I am only
+        // interested in invoking methods that are all defined in the AndroidComponentsExtension interface itself.
+        val typedExtension = AndroidComponentsExtension::class.java.cast(extension)
+
+        // order does not matter, it's just registering a callback at this point which will be called by AGP
+        // in the right order.
+        handleCallback(table, typedExtension, "beforeVariants", variantBuilderType)
+        { tomlDeclaration, variantApiType, selector ->
+            if (selector == null) {
+                typedExtension.beforeVariants { variantBuilder ->
+                    parse(tomlDeclaration, variantBuilder, variantApiType)
+                }
+            } else {
+                typedExtension.beforeVariants(selector) { variantBuilder ->
+                    parse(tomlDeclaration, variantBuilder, variantApiType)
+                }
+            }
+        }
+        handleCallback(table, typedExtension, "onVariants", variantType) {
+                tomlDeclaration, variantApiType, selector ->
+            if (selector == null) {
+                typedExtension.onVariants { variant ->
+                    parse(tomlDeclaration, variant, variantApiType)
+                }
+            } else {
+                typedExtension.onVariants(selector) { variant ->
+                    parse(tomlDeclaration, variant, variantApiType)
+                }
+            }
+        }
+    }
+
+    private fun handleCallback(
+        table: TomlTable,
+        typedExtension: AndroidComponentsExtension<*, *, *>,
+        variantApiName: String,
+        variantApiType: KType,
+        action: (tomlDeclaration: TomlTable, variantApiType: KType, selector: VariantSelector?) -> Unit
+    ) {
+        // let's look at setting that applies to all variants.
+        table.getTable(variantApiName)?.let {
+            action(it, variantApiType, null)
+        }
+
+        // and now let's look for dotted keys with variant name embedded.
+        table.entrySet()
+            .filter { entry -> entry.key.startsWith(variantApiName) }
+            .forEach { entry ->
+                entry.value?.let {
+                    val variantName = entry.key.substring(variantApiName.length + 1)
+                    action(it as TomlTable, variantApiType, typedExtension.selector().withName(variantName) )
+                }
+            }
+    }
+
+    private fun parse(tomlDeclaration: TomlTable, variantBuilder: VariantBuilder, variantBuilderType: KType) {
+        GenericDeclarativeParser(project, issueLogger)
+            .parse(tomlDeclaration, variantBuilderType.jvmErasure, variantBuilder)
+    }
+
+    private fun parse(tomlDeclaration: TomlTable, variant: Variant, variantType: KType) {
+        GenericDeclarativeParser(project, issueLogger)
+            .parse(tomlDeclaration, variantType.jvmErasure, variant)
+    }
+}

--- a/impl/src/main/kotlin/com/android/declarative/internal/variantApi/AndroidComponentsParser.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/variantApi/AndroidComponentsParser.kt
@@ -73,6 +73,16 @@ class AndroidComponentsParser(
         }
     }
 
+    /**
+     * Handle a Variant API callback style pf declarations.
+     *
+     * @param table the toml declarations
+     * @param typedExtension the type of the Variant API we are dealing with (Application, Library, etc...)
+     * @param variantApiName callback name like 'onVariants' or 'beforeVariants'
+     * @param variantApiType type of instance passed to the Variant API callback so for 'onVariants', it's
+     * ApplicationVariant (if dealing with an application) while for 'beforeVariants`, it's ApplicationVariantBuilder.
+     * @param action lambda function to register callbacks on [typedExtension] for each target variants.
+     */
     private fun handleCallback(
         table: TomlTable,
         typedExtension: AndroidComponentsExtension<*, *, *>,

--- a/impl/src/test/kotlin/com/android/declarative/internal/agp/AgpDslTest.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/agp/AgpDslTest.kt
@@ -18,7 +18,6 @@ abstract class AgpDslTest {
     val temporaryFolder= TemporaryFolder()
 
     lateinit var project: Project
-
     @Before
     fun setup() {
         File(temporaryFolder.root, "gradle.properties").writeText(
@@ -30,4 +29,5 @@ abstract class AgpDslTest {
             .withProjectDir(temporaryFolder.root)
             .build()
     }
+
 }

--- a/impl/src/test/kotlin/com/android/declarative/internal/agp/ApplicationVariantApiTest.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/agp/ApplicationVariantApiTest.kt
@@ -1,0 +1,79 @@
+package com.android.declarative.internal.agp
+
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.ApplicationVariant
+import com.android.build.api.variant.ApplicationVariantBuilder
+import com.android.build.api.variant.VariantSelector
+import com.android.declarative.internal.fixtures.FakeAndroidComponentsExtension
+import com.android.declarative.internal.variantApi.AndroidComponentsParser
+import org.gradle.api.provider.Property
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.tomlj.Toml
+
+class ApplicationVariantApiTest: AgpDslTest() {
+
+    @Mock
+    lateinit var variantBuilder: ApplicationVariantBuilder
+
+    @Mock
+    lateinit var variant: ApplicationVariant
+
+    @Mock
+    lateinit var selector: VariantSelector
+
+    private val extension: AndroidComponentsExtension<ApplicationExtension, ApplicationVariantBuilder, ApplicationVariant> by lazy {
+        FakeAndroidComponentsExtension(
+            selector,
+            variantBuilder,
+            variant
+        )
+    }
+
+    @Test
+    fun testVariantBuilderEnable() {
+
+        Mockito.`when`(selector.withName("debug")).thenReturn(selector)
+
+        val toml = Toml.parse(
+            """
+            [androidComponents."beforeVariants.debug"]
+            enable = false
+        """.trimIndent()
+        )
+        AndroidComponentsParser(project).parse(
+            toml.getTable("androidComponents")!!,
+            ApplicationAndroidComponentsExtension::class,
+            extension
+        )
+        Mockito.verify(selector).withName("debug")
+        Mockito.verify(variantBuilder).enable = false
+    }
+
+    @Test
+    fun testApplicationVariantEnable() {
+
+        Mockito.`when`(selector.withName("debug")).thenReturn(selector)
+        @Suppress("UNCHECKED_CAST")
+        val applicationIdProperty = Mockito.mock(Property::class.java) as Property<String>
+        Mockito.`when`(variant.applicationId).thenReturn(applicationIdProperty)
+
+        val toml = Toml.parse(
+            """
+            [androidComponents."onVariants.debug"]
+            applicationId = "some.app"
+        """.trimIndent()
+        )
+        AndroidComponentsParser(project).parse(
+            toml.getTable("androidComponents")!!,
+            ApplicationAndroidComponentsExtension::class,
+            extension
+        )
+        Mockito.verify(selector).withName("debug")
+        Mockito.verify(variant).applicationId
+        Mockito.verify(applicationIdProperty).set("some.app")
+    }
+}

--- a/impl/src/test/kotlin/com/android/declarative/internal/agp/ApplicationVariantApiTest.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/agp/ApplicationVariantApiTest.kt
@@ -54,7 +54,7 @@ class ApplicationVariantApiTest: AgpDslTest() {
     }
 
     @Test
-    fun testApplicationVariantEnable() {
+    fun testVariantApplicationId() {
 
         Mockito.`when`(selector.withName("debug")).thenReturn(selector)
         @Suppress("UNCHECKED_CAST")

--- a/impl/src/test/kotlin/com/android/declarative/internal/agp/BuildTypeTest.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/agp/BuildTypeTest.kt
@@ -18,24 +18,17 @@ package com.android.declarative.internal.agp
 
 import com.android.build.api.dsl.ApplicationBuildType
 import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.ProductFlavor
 import com.android.declarative.internal.AbstractDeclarativePlugin
 import com.android.declarative.internal.GenericDeclarativeParser
 import com.android.declarative.internal.IssueLogger
 import com.android.declarative.internal.JdkLoggerWrapper
 import com.google.common.truth.Truth
 import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.Project
-import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert.assertThrows
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
 import org.mockito.Mock
 import org.mockito.Mockito
-import org.mockito.junit.MockitoJUnit
-import org.mockito.junit.MockitoRule
-import org.mockito.quality.Strictness
 import org.tomlj.Toml
 import java.io.File
 import java.lang.RuntimeException
@@ -64,7 +57,7 @@ class BuildTypeTest: AgpDslTest() {
             [android.buildTypes.debug.minifyEnabled]
         """.trimIndent()
         )
-        val plugin = object: AbstractDeclarativePlugin() {
+        val plugin = object : AbstractDeclarativePlugin() {
             override val buildFileName: String
                 get() = "build.gradle.toml"
         }

--- a/impl/src/test/kotlin/com/android/declarative/internal/agp/BundleTest.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/agp/BundleTest.kt
@@ -10,8 +10,6 @@ import com.android.build.api.dsl.BundleLanguage
 import com.android.build.api.dsl.BundleTexture
 import com.android.build.api.dsl.SigningConfig
 import com.android.declarative.internal.GenericDeclarativeParser
-import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Before
 import org.junit.Test
 
 import org.mockito.Mock

--- a/impl/src/test/kotlin/com/android/declarative/internal/agp/LibraryVariantApiTest.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/agp/LibraryVariantApiTest.kt
@@ -58,13 +58,13 @@ class LibraryVariantApiTest : AgpDslTest() {
 
         Mockito.`when`(selector.withName("debug")).thenReturn(selector)
         @Suppress("UNCHECKED_CAST")
-        val namespaceProperty = Mockito.mock(Property::class.java) as Property<String>
-        Mockito.`when`(variant.namespace).thenReturn(namespaceProperty)
+        val pseudoLocalesEnabledProperty = Mockito.mock(Property::class.java) as Property<Boolean>
+        Mockito.`when`(variant.pseudoLocalesEnabled).thenReturn(pseudoLocalesEnabledProperty)
 
         val toml = Toml.parse(
             """
             [androidComponents."onVariants.debug"]
-            namespace = "some.lib"
+            pseudoLocalesEnabled = true
         """.trimIndent()
         )
         AndroidComponentsParser(project).parse(
@@ -73,7 +73,7 @@ class LibraryVariantApiTest : AgpDslTest() {
             extension
         )
         Mockito.verify(selector).withName("debug")
-        Mockito.verify(variant).namespace
-        Mockito.verify(namespaceProperty).set("some.lib")
+        Mockito.verify(variant).pseudoLocalesEnabled
+        Mockito.verify(pseudoLocalesEnabledProperty).set(true)
     }
 }

--- a/impl/src/test/kotlin/com/android/declarative/internal/agp/LibraryVariantApiTest.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/agp/LibraryVariantApiTest.kt
@@ -1,0 +1,79 @@
+package com.android.declarative.internal.agp
+
+import com.android.build.api.dsl.LibraryExtension
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
+import com.android.build.api.variant.LibraryVariant
+import com.android.build.api.variant.LibraryVariantBuilder
+import com.android.build.api.variant.VariantSelector
+import com.android.declarative.internal.fixtures.FakeAndroidComponentsExtension
+import com.android.declarative.internal.variantApi.AndroidComponentsParser
+import org.gradle.api.provider.Property
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.tomlj.Toml
+
+class LibraryVariantApiTest : AgpDslTest() {
+
+    @Mock
+    lateinit var variantBuilder: LibraryVariantBuilder
+
+    @Mock
+    lateinit var variant: LibraryVariant
+
+    @Mock
+    lateinit var selector: VariantSelector
+
+    private val extension: AndroidComponentsExtension<LibraryExtension, LibraryVariantBuilder, LibraryVariant> by lazy {
+        FakeAndroidComponentsExtension(
+            selector,
+            variantBuilder,
+            variant
+        )
+    }
+
+    @Test
+    fun testVariantBuilderEnable() {
+
+        Mockito.`when`(selector.withName("debug")).thenReturn(selector)
+
+        val toml = Toml.parse(
+            """
+            [androidComponents."beforeVariants.debug"]
+            enable = false
+        """.trimIndent()
+        )
+        AndroidComponentsParser(project).parse(
+            toml.getTable("androidComponents")!!,
+            LibraryAndroidComponentsExtension::class,
+            extension
+        )
+        Mockito.verify(selector).withName("debug")
+        Mockito.verify(variantBuilder).enable = false
+    }
+
+    @Test
+    fun testVariantEnable() {
+
+        Mockito.`when`(selector.withName("debug")).thenReturn(selector)
+        @Suppress("UNCHECKED_CAST")
+        val namespaceProperty = Mockito.mock(Property::class.java) as Property<String>
+        Mockito.`when`(variant.namespace).thenReturn(namespaceProperty)
+
+        val toml = Toml.parse(
+            """
+            [androidComponents."onVariants.debug"]
+            namespace = "some.lib"
+        """.trimIndent()
+        )
+        AndroidComponentsParser(project).parse(
+            toml.getTable("androidComponents")!!,
+            LibraryAndroidComponentsExtension::class,
+            extension
+        )
+        Mockito.verify(selector).withName("debug")
+        Mockito.verify(variant).namespace
+        Mockito.verify(namespaceProperty).set("some.lib")
+    }
+}

--- a/impl/src/test/kotlin/com/android/declarative/internal/agp/ProductFlavorTest.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/agp/ProductFlavorTest.kt
@@ -18,19 +18,14 @@ package com.android.declarative.internal.agp
 
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.ApplicationProductFlavor
+import com.android.build.api.dsl.ProductFlavor
 import com.android.declarative.internal.GenericDeclarativeParser
 import com.google.common.truth.Truth
 import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.times
-import org.mockito.junit.MockitoJUnit
-import org.mockito.junit.MockitoRule
-import org.mockito.quality.Strictness
 import org.tomlj.Toml
 
 class ProductFlavorTest: AgpDslTest() {
@@ -54,7 +49,7 @@ class ProductFlavorTest: AgpDslTest() {
             flavorDimensions = [ "version" ]
         """.trimIndent()
         )
-        GenericDeclarativeParser(project).parse(
+        GenericDeclarativeParser(project = project).parse(
             toml.getTable("android")!!,
             ApplicationExtension::class,
             extension
@@ -88,7 +83,7 @@ class ProductFlavorTest: AgpDslTest() {
             versionNameSuffix="-full"
         """.trimIndent()
         )
-        GenericDeclarativeParser(project).parse(
+        GenericDeclarativeParser(project = project).parse(
             toml.getTable("android")!!,
             ApplicationExtension::class,
             extension

--- a/impl/src/test/kotlin/com/android/declarative/internal/fixtures/FakeAndroidComponentsExtension.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/fixtures/FakeAndroidComponentsExtension.kt
@@ -1,0 +1,76 @@
+package com.android.declarative.internal.fixtures
+
+import com.android.build.api.AndroidPluginVersion
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.SdkComponents
+import com.android.build.api.instrumentation.manageddevice.ManagedDeviceRegistry
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.DslExtension
+import com.android.build.api.variant.Variant
+import com.android.build.api.variant.VariantBuilder
+import com.android.build.api.variant.VariantExtension
+import com.android.build.api.variant.VariantExtensionConfig
+import com.android.build.api.variant.VariantSelector
+import org.gradle.api.Action
+
+@Suppress("UnstableApiUsage")
+class FakeAndroidComponentsExtension<
+        CommonExtensionT: CommonExtension<*, *, *, *, *>,
+        VariantBuilderT: VariantBuilder,
+        VariantT: Variant>(
+    private val selector: VariantSelector,
+    private val variantBuilder: VariantBuilderT,
+    private val variant: VariantT,
+): AndroidComponentsExtension<CommonExtensionT, VariantBuilderT, VariantT> {
+
+    override val managedDeviceRegistry: ManagedDeviceRegistry
+        get() = TODO("Not yet implemented")
+    override val pluginVersion: AndroidPluginVersion
+        get() = TODO("Not yet implemented")
+    override val sdkComponents: SdkComponents
+        get() = TODO("Not yet implemented")
+
+    override fun finalizeDsl(callback: Action<CommonExtensionT>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun finalizeDsl(callback: (CommonExtensionT) -> Unit) {
+        TODO("Not yet implemented")
+    }
+
+    override fun registerSourceType(name: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun selector(): VariantSelector = selector
+
+
+    override fun registerExtension(
+        dslExtension: DslExtension,
+        configurator: (variantExtensionConfig: VariantExtensionConfig<VariantT>) -> VariantExtension
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun onVariants(selector: VariantSelector, callback: Action<VariantT>) {
+        callback.execute(variant)
+    }
+
+    override fun onVariants(selector: VariantSelector, callback: (VariantT) -> Unit) {
+        callback(variant)
+    }
+
+    @Deprecated("Replaced by finalizeDsl", replaceWith = ReplaceWith("finalizeDsl(callback)"))
+    override fun finalizeDSl(callback: Action<CommonExtensionT>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun beforeVariants(selector: VariantSelector, callback: Action<VariantBuilderT>) {
+        callback.execute(variantBuilder)
+
+    }
+
+    override fun beforeVariants(selector: VariantSelector, callback: (VariantBuilderT) -> Unit) {
+        callback(variantBuilder)
+    }
+}

--- a/tests/src/test-projects/simpleApplication/app/build.gradle.toml
+++ b/tests/src/test-projects/simpleApplication/app/build.gradle.toml
@@ -7,3 +7,6 @@ namespace = "com.example.app"
 
 [android.defaultConfig]
 minSdk = 21
+
+[androidComponents.beforeVariants.debug]
+enable = false

--- a/tests/src/test-projects/simpleApplication/app/build.gradle.toml
+++ b/tests/src/test-projects/simpleApplication/app/build.gradle.toml
@@ -8,5 +8,5 @@ namespace = "com.example.app"
 [android.defaultConfig]
 minSdk = 21
 
-[androidComponents.beforeVariants.debug]
+[androidComponents."beforeVariants.release"]
 enable = false


### PR DESCRIPTION
added the ability to have `androidComponents` in the toml declarative file. This applies only to be able to set properties, none of the APIs related to artifacts will ever be available.

So far, only intrinsic types and Property<*> are supported, support for other types like MapProperty<>, ListProperty<> will come in a subsequent CL.

Added simple tests for `application` and `library` androidComponents extensions.

Test: unit tests.
Bug: N/A