### PR TITLE
Add ability to include other toml buildscripts into a build script

### DIFF
--- a/impl/src/main/kotlin/com/android/declarative/internal/GenericDeclarativeParser.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/GenericDeclarativeParser.kt
@@ -43,6 +43,7 @@ import kotlin.reflect.jvm.jvmErasure
  */
 class GenericDeclarativeParser(
     private val project: Project,
+    private val cache: DslTypesCache = DslTypesCache(),
     private val issueLogger: IssueLogger =
         IssueLogger(false, LoggerWrapper(project.logger)),
 ) : DeclarativeFileParser {
@@ -129,7 +130,6 @@ class GenericDeclarativeParser(
     }
 
 
-    private val cache = DslTypesCache()
     private val contexts = ArrayDeque<Context>()
 
     override fun <T : Any> parse(table: TomlTable, type: KClass<out T>, extension: T) {

--- a/impl/src/main/kotlin/com/android/declarative/internal/variantApi/AndroidComponentsParser.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/variantApi/AndroidComponentsParser.kt
@@ -5,6 +5,7 @@ import com.android.build.api.variant.Variant
 import com.android.build.api.variant.VariantBuilder
 import com.android.build.api.variant.VariantSelector
 import com.android.declarative.internal.DeclarativeFileParser
+import com.android.declarative.internal.DslTypesCache
 import com.android.declarative.internal.GenericDeclarativeParser
 import com.android.declarative.internal.IssueLogger
 import com.android.declarative.internal.LoggerWrapper
@@ -20,8 +21,8 @@ import kotlin.reflect.jvm.jvmErasure
  */
 class AndroidComponentsParser(
     private val project: Project,
-    private val issueLogger: IssueLogger =
-        IssueLogger(false, LoggerWrapper(project.logger)),
+    private val cache: DslTypesCache = DslTypesCache(),
+    private val issueLogger: IssueLogger = IssueLogger(false, LoggerWrapper(project.logger)),
 ): DeclarativeFileParser {
 
     override fun <T: Any> parse(table: TomlTable, type: KClass<out T>, extension: T) {
@@ -107,12 +108,12 @@ class AndroidComponentsParser(
     }
 
     private fun parse(tomlDeclaration: TomlTable, variantBuilder: VariantBuilder, variantBuilderType: KType) {
-        GenericDeclarativeParser(project, issueLogger)
+        GenericDeclarativeParser(project, cache, issueLogger)
             .parse(tomlDeclaration, variantBuilderType.jvmErasure, variantBuilder)
     }
 
     private fun parse(tomlDeclaration: TomlTable, variant: Variant, variantType: KType) {
-        GenericDeclarativeParser(project, issueLogger)
+        GenericDeclarativeParser(project, cache, issueLogger)
             .parse(tomlDeclaration, variantType.jvmErasure, variant)
     }
 }

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -37,4 +37,5 @@ dependencies {
 	testImplementation(libs.truth)
 	testImplementation(libs.testutils)
 	testImplementation(libs.testFramework)
+	testImplementation(libs.toolsCommon)
 }

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/build.gradle.toml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/build.gradle.toml
@@ -1,0 +1,13 @@
+includeBuildFiles = ["../toml/paid.toml", "../toml/demo.toml"]
+
+[[plugins]]
+id = "com.android.application"
+
+[android]
+compileSdk = 33
+namespace = "com.example.app"
+
+[android.defaultConfig]
+minSdk = 21
+
+[dependencies.implementation.lib]

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/src/androidTest/java/com/example/app/HelloWorldTest.java
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/src/androidTest/java/com/example/app/HelloWorldTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.app;
+
+import android.support.test.filters.MediumTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.widget.TextView;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class HelloWorldTest {
+    @Rule public ActivityTestRule<HelloWorld> rule = new ActivityTestRule<>(HelloWorld.class);
+    private TextView mTextView;
+
+    @Before
+    public void setUp() throws Exception {
+        final HelloWorld a = rule.getActivity();
+        // ensure a valid handle to the activity has been returned
+        Assert.assertNotNull(a);
+        mTextView = (TextView) a.findViewById(R.id.text);
+
+    }
+
+    @Test
+    @MediumTest
+    public void testPreconditions() {
+        Assert.assertNotNull(mTextView);
+    }
+}

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/src/main/AndroidManifest.xml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/src/main/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      android:versionCode="1"
+      android:versionName="1.0">
+
+    <application android:label="@string/app_name">
+        <activity android:name=".HelloWorld"
+                  android:exported="true"
+                  android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/src/main/java/com/example/app/HelloWorld.java
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/src/main/java/com/example/app/HelloWorld.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.app;
+
+import android.app.Activity;
+import android.os.Bundle;
+import com.example.helloworld.Lib1Utils;
+
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
+public class HelloWorld extends Activity {
+    /** Called when the activity is first created. */
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+
+        super.onCreate(savedInstanceState);
+        Logger.getLogger("app").log(Level.INFO, new Lib1Utils().someUtility());
+        setContentView(R.layout.main);
+        // onCreate
+    }
+}

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/src/main/res/layout/main.xml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/src/main/res/layout/main.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    >
+<TextView
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:text="hello world!"
+    android:id="@+id/text"
+    />
+</LinearLayout>

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/src/main/res/values/strings.xml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/src/main/res/values/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+    <string name="app_name">HelloWorld</string>
+</resources>

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/build.gradle.toml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/build.gradle.toml
@@ -1,0 +1,10 @@
+includeBuildFiles = ["../toml/common.toml"]
+
+[[plugins]]
+id = "com.android.library"
+
+[android]
+namespace = "com.example.helloworld"
+
+[android.defaultConfig]
+minSdk = 21

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/androidTest/java/com/example/helloworld/HelloWorldTest.java
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/androidTest/java/com/example/helloworld/HelloWorldTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.helloworld;
+
+import android.support.test.filters.MediumTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.widget.TextView;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class HelloWorldTest {
+    @Rule public ActivityTestRule<HelloWorld> rule = new ActivityTestRule<>(HelloWorld.class);
+    private TextView mTextView;
+
+    @Before
+    public void setUp() throws Exception {
+        final HelloWorld a = rule.getActivity();
+        // ensure a valid handle to the activity has been returned
+        Assert.assertNotNull(a);
+        mTextView = (TextView) a.findViewById(R.id.text);
+
+    }
+
+    @Test
+    @MediumTest
+    public void testPreconditions() {
+        Assert.assertNotNull(mTextView);
+    }
+}

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/main/AndroidManifest.xml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/main/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      android:versionCode="1"
+      android:versionName="1.0">
+
+    <application android:label="@string/app_name">
+        <activity android:name=".HelloWorld"
+                  android:exported="true"
+                  android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/main/java/com/example/helloworld/HelloWorld.java
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/main/java/com/example/helloworld/HelloWorld.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.helloworld;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+public class HelloWorld extends Activity {
+    /** Called when the activity is first created. */
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.main);
+        // onCreate
+    }
+}

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/main/java/com/example/helloworld/Lib1Utils.java
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/main/java/com/example/helloworld/Lib1Utils.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.helloworld;
+
+public class Lib1Utils {
+    public String someUtility() {
+        return "Lib1" + System.currentTimeMillis();
+    }
+}

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/main/res/layout/main.xml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/main/res/layout/main.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    >
+<TextView
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:text="hello world!"
+    android:id="@+id/text"
+    />
+</LinearLayout>

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/main/res/values/strings.xml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/lib/src/main/res/values/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+    <string name="app_name">HelloWorld</string>
+</resources>

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/settings.gradle.toml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/settings.gradle.toml
@@ -1,0 +1,8 @@
+include = [ ":app", ":lib" ]
+
+[[pluginsManagement.repositories.inheritSettings]]
+
+[[plugins]]
+module = "com.android.tools.build:gradle"
+version = "8.3.0-dev"
+

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/toml/common.toml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/toml/common.toml
@@ -1,0 +1,5 @@
+[android]
+compileSdk = 33
+
+[android.defaultConfig]
+minSdk = 21

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/toml/demo.toml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/toml/demo.toml
@@ -1,0 +1,7 @@
+[android.productFlavors.demo]
+dimension="version"
+applicationIdSuffix=".demo"
+versionNameSuffix="-demo"
+
+[android.defaultConfig]
+minSdk = 21

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/toml/paid.toml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/toml/paid.toml
@@ -1,0 +1,12 @@
+
+[android]
+flavorDimensions = [ "version" ]
+compileSdk = 31
+
+[android.productFlavors.paid]
+dimension="version"
+applicationIdSuffix=".paid"
+versionNameSuffix="-paid"
+
+[android.defaultConfig]
+minSdk = 19

--- a/tests/src/test/kotlin/com/android/declarative/tests/samples/NestedBuildScriptSingleLibraryApplication.kt
+++ b/tests/src/test/kotlin/com/android/declarative/tests/samples/NestedBuildScriptSingleLibraryApplication.kt
@@ -1,0 +1,43 @@
+package com.android.declarative.tests.samples
+
+import com.android.declarative.infra.DeclarativeTestProject
+import com.android.declarative.infra.DeclarativeTestProjectBuilder
+import com.android.testutils.truth.PathSubject.assertThat
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class NestedBuildScriptSingleLibraryApplication {
+    @Rule
+    @JvmField
+    val project: DeclarativeTestProject = DeclarativeTestProjectBuilder.createTestProject(
+        File(DeclarativeTestProjectBuilder().getTestProjectsDir().toFile(), "nestedBuildScriptSingleLibApplication")
+    ).create()
+
+    @Test
+    fun buildAll() {
+        project.executor().run("assembleDebug")
+        val appProject = project.getSubproject("app")
+        // test that demo.toml build file is included and applied
+        val demoManifest = appProject.getMergedManifestFile("demo", "debug")
+        assertThat(appProject.getOutputMetadataJson("demo", "debug"))
+            .contains(""""applicationId": "com.example.app.demo"""")
+
+        // test that minSdkVersion defined in demo.toml build file is overridden
+        assertThat(demoManifest).contains("""android:minSdkVersion="21"""")
+
+        // test that paid.toml build file is included and applied
+        val paidManifest = appProject.getMergedManifestFile("paid", "debug")
+        assertThat(appProject.getOutputMetadataJson("paid", "debug"))
+            .contains(""""applicationId": "com.example.app.paid"""")
+        // test that minSdkVersion defined in paid.toml build file is overridden
+        assertThat(paidManifest).contains("""android:minSdkVersion="21"""")
+
+
+        // test that libProject is built successfully
+        val libProject = project.getSubproject("lib")
+        assertThat(libProject.getMergedManifestFile("debug"))
+            .contains("""android:minSdkVersion="21"""")
+
+    }
+}


### PR DESCRIPTION
A Toml buildscript can define an array of relative path to other Toml buildscripts which will be recursively parsed depth first and applied to extension objects. The paths are relative to the current buildscript. Processing a Toml buildscript creates a side effect in form of cached extension objects. All build script parsing now shares the same cache. The scripts are processed in the order they are declared in the array and the nested file is processed before the file that includes it. Plugins are applied first to make the extension objects available to configure before the nested file processing ensue. The result of this order of processing is that the declarations in the included file are overriden by the file that includes it. Similarly, the files that precedes in the incude array have it's declarations overriden by the files that are at the higer index in the include array in case of conflict. Current test include loading a single library project with the nested buildscripts without verification. More tests will be added as we build our test infrastructure for verifying whether the DSL is applied correctly or not.