### PR TITLE
Update Gradle to 8.3 in wrapper - clean version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Feb 27 16:35:22 PST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Old version caused
> Task :tools:base:build-system:gradle-core:compileKotlin FAILED
BuildIdentifierMethods.kt:29:12 Unresolved reference: buildTreePath