### PR TITLE
changed all dependencies declaration to new format

### DIFF
--- a/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
@@ -70,7 +70,9 @@ class DeclarativePlugin @Inject constructor(
         // plugins must be applied first so extensions are correctly registered.
         parsedDecl.getArray("plugins")?.also { plugins ->
             PluginParser().parse(plugins).forEach { pluginInfo ->
-                project.apply(mapOf("plugin" to pluginInfo.id))
+                println("In project, applying ${pluginInfo.id}")
+                project.pluginManager.apply(pluginInfo.id)
+//                project.apply(mapOf("plugin" to pluginInfo.id))
             }
         }
 

--- a/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
@@ -72,7 +72,6 @@ class DeclarativePlugin @Inject constructor(
             PluginParser().parse(plugins).forEach { pluginInfo ->
                 println("In project, applying ${pluginInfo.id}")
                 project.pluginManager.apply(pluginInfo.id)
-//                project.apply(mapOf("plugin" to pluginInfo.id))
             }
         }
 

--- a/impl/src/main/kotlin/com/android/declarative/internal/DependencyProcessor.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/DependencyProcessor.kt
@@ -18,10 +18,12 @@
 package com.android.declarative.internal
 
 import com.android.declarative.internal.model.DependencyInfo
+import com.android.declarative.internal.model.DependencyInfo.Alias
+import com.android.declarative.internal.model.DependencyInfo.ExtensionFunction
+import com.android.declarative.internal.model.DependencyInfo.Files
+import com.android.declarative.internal.model.DependencyInfo.Maven
+import com.android.declarative.internal.model.DependencyInfo.Notation
 import com.android.declarative.internal.model.DependencyType
-import com.android.declarative.internal.model.FilesDependencyInfo
-import com.android.declarative.internal.model.MavenDependencyInfo
-import com.android.declarative.internal.model.NotationDependencyInfo
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.DependencyFactory
 import org.gradle.api.artifacts.dsl.DependencyHandler
@@ -42,7 +44,7 @@ class DependencyProcessor(
     fun process(dependencies: List<DependencyInfo>) {
         dependencies.forEach { dependency ->
             when(dependency) {
-                is NotationDependencyInfo -> {
+                is Notation -> {
                     if (dependency.type == DependencyType.PROJECT) {
                         addProjectDependency(
                             dependency.configuration,
@@ -54,17 +56,23 @@ class DependencyProcessor(
                         )
                     }
                 }
-                is FilesDependencyInfo -> {
+                is Files -> {
                     addFilesDependency(dependency)
                 }
-                is MavenDependencyInfo -> {
+                is Maven -> {
                     addLibraryDependency(dependency)
+                }
+                is ExtensionFunction -> {
+                    throw RuntimeException("Not Supported yet !")
+                }
+                is Alias -> {
+                    throw RuntimeException("Version catalogs not supported yet.")
                 }
             }
         }
     }
 
-    private fun addFilesDependency(dependency: FilesDependencyInfo) {
+    private fun addFilesDependency(dependency: Files) {
         val fileCollection = fileCollectionFactory()
         dependency.files.forEach(fileCollection::from)
         println("adding files dependency ${dependency.files} to ${dependency.configuration}")
@@ -76,7 +84,7 @@ class DependencyProcessor(
         )
     }
 
-    private fun addLibraryDependency(dependency: MavenDependencyInfo) {
+    private fun addLibraryDependency(dependency: Maven) {
         println("Adding maven ${dependency.name} to ${dependency.configuration}")
         dependencyHandler.add(
             dependency.configuration,
@@ -94,7 +102,7 @@ class DependencyProcessor(
         dependencyHandler.add(configurationName, dependencyFactory.create(dependencyTarget))
     }
 
-    private fun addNotationDependency(dependencyInfo: NotationDependencyInfo) {
+    private fun addNotationDependency(dependencyInfo: Notation) {
         val dependency = when(dependencyInfo.notation) {
             "localGroovy" -> dependencyFactory.localGroovy()
             "gradleApi" -> dependencyFactory.gradleApi()

--- a/impl/src/main/kotlin/com/android/declarative/internal/IncludedBuildCache.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/IncludedBuildCache.kt
@@ -1,0 +1,49 @@
+import org.gradle.api.Project
+import java.io.File
+import java.util.Properties
+
+
+class IncludedBuildPluginInfo(
+    val classesDir: File,
+    val resourcesDir: File,
+)
+
+class IncludedBuildCache(
+    private val project: Project,
+    private val includedBuildDir: File,
+) {
+    private val markerFileLookup = "**/META-INF/gradle-plugins/*.properties"
+
+    private val markerFiles: Set<File> =
+        project.fileTree(includedBuildDir) {
+            it.include(markerFileLookup)
+        }.files
+
+    fun resolvePluginById(id:String): IncludedBuildPluginInfo? {
+        markerFiles.first {
+            it.name == "$id.properties"
+        }?.let { markerFile ->
+            loadPluginMarkerFile(markerFile)?.let { implementationClassName ->
+
+                val classFile = project.fileTree(includedBuildDir) {
+                    it.include("**/$implementationClassName.class")
+                }
+
+                val resourcesDir = markerFile.parentFile.parentFile.parentFile
+
+                val classesDir = classFile.singleFile.absolutePath.substring(0,
+                    classFile.singleFile.absolutePath.length -
+                            (implementationClassName.length + ".class".length + File.separator.length)
+                )
+
+                return IncludedBuildPluginInfo(File(classesDir), resourcesDir)
+            }
+        }
+        return null
+    }
+
+    private fun loadPluginMarkerFile(markerFile: File): String =
+        Properties().also {
+            it.load(markerFile.reader())
+        }.getProperty("implementation-class")
+}

--- a/impl/src/main/kotlin/com/android/declarative/internal/SettingsDeclarativePlugin.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/SettingsDeclarativePlugin.kt
@@ -162,8 +162,8 @@ class SettingsDeclarativePlugin @Inject constructor(
                     .forEach("focus", listOfProjects::add)
                 return listOfProjects.toList()
             }
-            if (parsedDecl.contains("focus")) {
-                return parsedDecl.safeGetString("focus").split(",")
+            parsedDecl.getString("focus")?.let{
+                return it.split(",")
             }
         }
         // fallback, focus mode is not active.
@@ -214,15 +214,10 @@ class SettingsDeclarativePlugin @Inject constructor(
                 }
                 else if (table.contains("id")) {
                     println("Adding ${table.safeGetString("id")} to project's classpath")
-                    //project.apply(mapOf("plugin" to table.safeGetString("id")))
                     project.buildscript.dependencies.add(
                         ScriptHandler.CLASSPATH_CONFIGURATION,
                         "name: ${table.safeGetString("id")}"
                     )
-//                    project.buildscript.dependencies.add(
-//                        ScriptHandler.CLASSPATH_CONFIGURATION,
-//                        table.safeGetString("id")
-//                    )
                 }
             }
             // apply declarative plugin last as it will immediately apply the project's declared plugins which

--- a/impl/src/main/kotlin/com/android/declarative/internal/SettingsDeclarativePlugin.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/SettingsDeclarativePlugin.kt
@@ -15,10 +15,12 @@
  */
 package com.android.declarative.internal
 
+import com.android.declarative.internal.configurators.RepositoriesConfigurator
 import com.android.declarative.internal.model.ProjectDependenciesDAG
 import com.android.declarative.internal.parsers.DeclarativeFileParser
 import com.android.declarative.internal.parsers.DependenciesResolver
-import com.android.declarative.internal.toml.checkElementsPresence
+import com.android.declarative.internal.parsers.DependencyResolutionManagementParser
+import com.android.declarative.internal.parsers.PluginManagementParser
 import com.android.declarative.internal.toml.forEach
 import com.android.declarative.internal.toml.forEachTable
 import com.android.declarative.internal.toml.safeGetString
@@ -30,7 +32,6 @@ import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.internal.time.Time
 import org.tomlj.TomlParseResult
 import java.io.File
-import java.net.URL
 import java.util.logging.Logger
 import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
@@ -78,6 +79,21 @@ class SettingsDeclarativePlugin @Inject constructor(
             parseResult
         }
 
+        declareSubProjectsToGradle(settingsDeclarations, settings)
+
+        settingsDeclarations.getTable("pluginManagement")
+            ?.let { pluginManagementDeclarations ->
+                val pluginManagementInfo = PluginManagementParser(logger).parseToml(pluginManagementDeclarations)
+                // so far, we only handle pluginManagement's repositories declarations.
+                RepositoriesConfigurator(logger).apply(
+                    "pluginManagement",
+                    settings.pluginManagement.repositories,
+                    pluginManagementInfo.repositories,
+                )
+
+                pluginManagementInfo.includedBuilds.forEach(settings.pluginManagement::includeBuild)
+            }
+
         settings.pluginManagement { pluginManagement ->
             // declare our plugin version to the plugins management
             pluginManagement.plugins.id("com.android.experiments.declarative").version(Constants.PLUGIN_VERSION)
@@ -88,15 +104,27 @@ class SettingsDeclarativePlugin @Inject constructor(
                     // if the user does not specify the `id`, it means they are not interested in providing plugins
                     // versions to the plugin management and probably solely relies on classpath configuration.
                     if (table.contains("id")) {
-                        table.checkElementsPresence("plugins", "id", "version")
                         println("Applying plugin ${table.getString("id")} version ${table.getString("version")}")
-                        pluginManagement.plugins
+                        val pluginDependencySpec = pluginManagement.plugins
                             .id(table.safeGetString("id"))
-                            .version(table.safeGetString("version"))
-                            .apply(false)
+                        if (table.contains("version")) {
+                            pluginDependencySpec.version(table.safeGetString("version"))
+                        }
+
                     }
                 }
             }
+        }
+
+
+        settingsDeclarations.getTable("dependencyResolutionManagement")?.also { dependencyResolutionManagementDeclarations ->
+            val dependencyResolutionManagementInfo =
+                DependencyResolutionManagementParser(logger).parseToml(dependencyResolutionManagementDeclarations)
+            RepositoriesConfigurator(logger).apply(
+                "DependencyResolutionManagementInfo",
+                settings.dependencyResolutionManagement.repositories,
+                dependencyResolutionManagementInfo.repositories,
+            )
         }
 
         settings.gradle.beforeProject { project ->
@@ -106,10 +134,9 @@ class SettingsDeclarativePlugin @Inject constructor(
             if (project.path == ":") {
                 configureRootProject(settingsDeclarations, project)
             } else {
-                configureSubProject(project)
+                configureSubProject(settingsDeclarations, project)
             }
         }
-        declareSubProjectsToGradle(settingsDeclarations, settings)
     }
 
     private fun getListOfFocusedProjects(
@@ -135,24 +162,12 @@ class SettingsDeclarativePlugin @Inject constructor(
                     .forEach("focus", listOfProjects::add)
                 return listOfProjects.toList()
             }
-            return if (parsedDecl.contains("focus")) {
-                parsedDecl.safeGetString("focus").split(",")
-            } else {
-                val listOfProjects = mutableListOf<String>()
-                val regex = Regex("(:[^:]*):(.*)")
-                settings.gradle.startParameter.taskNames.forEach {
-                    if (regex.matches(it)) {
-                        regex.matchEntire(it)?.groups?.get(1)?.value?.let { projectName ->
-                            println("Focusing on $projectName from task name $it")
-                            listOfProjects.add(projectName)
-                        }
-                    }
-                }
-                listOfProjects.toList()
+            if (parsedDecl.contains("focus")) {
+                return parsedDecl.safeGetString("focus").split(",")
             }
-        } else {
-            return listOf()
         }
+        // fallback, focus mode is not active.
+        return listOf()
     }
 
     /**
@@ -163,27 +178,9 @@ class SettingsDeclarativePlugin @Inject constructor(
      * @param project the sub module's [Project]
      */
     private fun addRepositoriesToSubProject(settingsDeclarations: TomlParseResult, settings: Settings, project: Project) {
-        settingsDeclarations.getTable("pluginsManagement.repositories")?.entrySet()?.forEach {
-            if (it.key == "inheritSettings") {
-                settings.pluginManagement.repositories.forEach {
-                    println("Adding ${it.name} to project's buildscript")
-                    project.buildscript.repositories.add(it)
-                }
-            } else {
-                val repoInfo =
-                    settingsDeclarations.getTable("pluginsManagement.repositories")?.getTable(it.key)
-                        ?: throw RuntimeException("No 'url' and 'type' specified for repository `${it.key}`")
-                val repoType = repoInfo.getString("type")
-                if (repoType != "maven") {
-                    throw RuntimeException("Only maven repository are supported at this point, unsupported repository type : $repoType")
-                }
-
-                println("Adding $repoType repository named ${it.key} to project's buildscript")
-                project.buildscript.repositories.maven { repo ->
-                    repo.name = it.key
-                    repo.url = URL(repoInfo.getString("url")).toURI()
-                }
-            }
+        settings.pluginManagement.repositories.forEach {
+            println("Adding ${it.name} to project's buildscript")
+            project.buildscript.repositories.add(it)
         }
     }
 
@@ -192,7 +189,7 @@ class SettingsDeclarativePlugin @Inject constructor(
      *
      * @param project the Gradle's [Project] to configure
      */
-    private fun configureSubProject(project: Project) {
+    private fun configureSubProject(settingsDeclarations: TomlParseResult, project: Project) {
 
         val declarativeFile = DeclarativeFileValueSource.enlist(
             project.providers,
@@ -201,6 +198,35 @@ class SettingsDeclarativePlugin @Inject constructor(
 
         // only registers the declarative plugin if there is a build.gradle.toml file present in the project dir.
         if (declarativeFile.isPresent) {
+            settingsDeclarations.getArray("plugins")?.forEachTable { table ->
+                // TODO : reconcile and use DependencyParser.
+                if (table.contains("module")) {
+                    val notation = if (table.contains("version")) {
+                        "${table.safeGetString("module")}:${table.safeGetString("version")}"
+                    } else {
+                        table.safeGetString("module")
+                    }
+                    println("Adding $notation to classpath")
+                    project.buildscript.dependencies.add(
+                        ScriptHandler.CLASSPATH_CONFIGURATION,
+                        notation
+                    )
+                }
+                else if (table.contains("id")) {
+                    println("Adding ${table.safeGetString("id")} to project's classpath")
+                    //project.apply(mapOf("plugin" to table.safeGetString("id")))
+                    project.buildscript.dependencies.add(
+                        ScriptHandler.CLASSPATH_CONFIGURATION,
+                        "name: ${table.safeGetString("id")}"
+                    )
+//                    project.buildscript.dependencies.add(
+//                        ScriptHandler.CLASSPATH_CONFIGURATION,
+//                        table.safeGetString("id")
+//                    )
+                }
+            }
+            // apply declarative plugin last as it will immediately apply the project's declared plugins which
+            // are probably added to the classpath right above.
             project.apply(mapOf("plugin" to "com.android.experiments.declarative"))
         } else {
             println("${project.path} ignored, build files are present")
@@ -226,14 +252,27 @@ class SettingsDeclarativePlugin @Inject constructor(
                 // buildscript classpath, it just applies it (assuming it is already in the classpath).
                 println("Configuring root project")
                 project.buildscript.dependencies.also { dependencyHandler ->
-            settingsDeclarations.getArray("plugins")?.forEachTable { table ->
-                table.checkElementsPresence("plugins", "module", "version")
-                val notation = "${table.safeGetString("module")}:${table.safeGetString("version")}"
-                println("Adding $notation to classpath")
-                dependencyHandler.add(
-                    ScriptHandler.CLASSPATH_CONFIGURATION,
-                    notation)
-            }
+                    settingsDeclarations.getArray("plugins")?.forEachTable { table ->
+                        // TODO : reconcile and use DependencyParser.
+                        if (table.contains("module")) {
+                            val notation = if (table.contains("version")) {
+                                "${table.safeGetString("module")}:${table.safeGetString("version")}"
+                            } else {
+                                "${table.safeGetString("module")}"
+                            }
+                            println("Adding $notation to classpath")
+                            dependencyHandler.add(
+                                ScriptHandler.CLASSPATH_CONFIGURATION,
+                                notation
+                            )
+                        } else {
+                            println("For root, would like to  add ${table.safeGetString("id")}")
+        //                    dependencyHandler.add(
+        //                        ScriptHandler.CLASSPATH_CONFIGURATION,
+        //                        "id: ${table.safeGetString("id")}"
+        //                    )
+                        }
+                    }
         }
     }
 

--- a/impl/src/main/kotlin/com/android/declarative/internal/configurators/RepositoriesConfigurator.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/configurators/RepositoriesConfigurator.kt
@@ -1,0 +1,56 @@
+package com.android.declarative.internal.configurators
+
+import com.android.declarative.internal.IssueLogger
+import com.android.declarative.internal.model.PreDefinedRepositoryInfo
+import com.android.declarative.internal.model.RepositoryInfo
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+
+/**
+ * Configures a [RepositoryHandler] with repositories.
+ */
+class RepositoriesConfigurator(
+    private val issueLogger: IssueLogger,
+) {
+
+    /**
+     * Add the [List] of [RepositoryInfo]s to the provided [RepositoryHandler]
+     *
+     * @param context a user friendly string to provide context to error/warning messages.
+     * @param repositoryHandler the [RepositoryHandler] to add repositories to.
+     * @param repositoryModels [List] of repository model to add.
+     */
+    fun apply(
+        context: String,
+        repositoryHandler: RepositoryHandler,
+        repositoryModels: List<RepositoryInfo>
+    ) {
+        repositoryModels.forEach {
+            when(it) {
+                is PreDefinedRepositoryInfo -> {
+                    when(it.name) {
+                        "google" -> {
+                            issueLogger.logger.info("Adding google repository to $context")
+                            repositoryHandler.google()
+                        }
+                        "mavenCentral" -> {
+                            issueLogger.logger.info("Adding mavenCentral repository to $context")
+                            repositoryHandler.mavenCentral()
+                        }
+                        "mavenLocal" -> {
+                            issueLogger.logger.info("Adding mavenCentral repository to $context")
+                            repositoryHandler.mavenLocal()
+                        }
+                        "gradlePluginPortal" -> {
+                            issueLogger.logger.info("Adding gradlePluginPortal repository to $context")
+                            repositoryHandler.gradlePluginPortal()
+                        }
+                        else -> {
+                            throw RuntimeException("Unknown repository named : ${it.name}")
+                        }
+                    }
+                }
+                else -> throw RuntimeException("Unhandled repository type: ${it.type}, ${it.javaClass}")
+            }
+        }
+    }
+}

--- a/impl/src/test/kotlin/com/android/declarative/internal/DependencyProcessorTest.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/DependencyProcessorTest.kt
@@ -16,10 +16,10 @@
 
 package com.android.declarative.internal
 
+import com.android.declarative.internal.model.DependencyInfo.Files
+import com.android.declarative.internal.model.DependencyInfo.Maven
+import com.android.declarative.internal.model.DependencyInfo.Notation
 import com.android.declarative.internal.model.DependencyType
-import com.android.declarative.internal.model.FilesDependencyInfo
-import com.android.declarative.internal.model.MavenDependencyInfo
-import com.android.declarative.internal.model.NotationDependencyInfo
 import com.android.utils.ILogger
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ExternalModuleDependency
@@ -37,7 +37,6 @@ import org.mockito.Mockito.times
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
 import org.mockito.quality.Strictness
-import org.tomlj.Toml
 
 @Suppress("UnstableApiUsage")
 class DependencyProcessorTest {
@@ -65,7 +64,7 @@ class DependencyProcessorTest {
         val parser = createDependenciesParser()
         val dependency = createSubProjectAndWireDependency(":lib1")
         val dependencies = listOf(
-            NotationDependencyInfo(
+            Notation(
                 DependencyType.PROJECT,
                 "implementation",
                 ":lib1"
@@ -83,12 +82,12 @@ class DependencyProcessorTest {
         val dependency1 = createSubProjectAndWireDependency(":lib1")
         val dependency2 = createSubProjectAndWireDependency(":lib2")
         val dependencies = listOf(
-            NotationDependencyInfo(
+            Notation(
                 DependencyType.PROJECT,
                 "implementation",
                 ":lib1"
             ),
-            NotationDependencyInfo(
+            Notation(
                 DependencyType.PROJECT,
                 "testImplementation",
                 ":lib2"
@@ -105,7 +104,7 @@ class DependencyProcessorTest {
         val parser = createDependenciesParser()
         val dependency = createExternalDependency("org.mockito:mockito-core:4.8.0")
         val dependencies = listOf(
-            NotationDependencyInfo(
+            Notation(
                 DependencyType.NOTATION,
                 configuration = "implementation",
                 notation = "org.mockito:mockito-core:4.8.0",
@@ -121,7 +120,7 @@ class DependencyProcessorTest {
         val parser = createDependenciesParser()
         val dependency = createExternalDependency("org.mockito", "mockito-core", "4.8.0")
         val dependencies = listOf(
-            MavenDependencyInfo(
+            Maven(
                 configuration = "implementation",
                 group = "org.mockito",
                 name = "mockito-core",
@@ -138,22 +137,14 @@ class DependencyProcessorTest {
         val parser = createDependenciesParser()
         val dependency1 = createExternalDependency("org.mockito", "mockito-core", "4.8.0")
         val dependency2 = createExternalDependency("org.junit", "junit", "5.7.0")
-
-        val toml = Toml.parse(
-            """
-            [dependencies.testImplementation]
-            mockito = { group = "org.mockito", name = "mockito-core", version = "4.8.0" }
-            junit = { group = "org.junit", name = "junit", version = "5.7.0" }
-        """.trimIndent()
-        )
         val dependencies = listOf(
-            MavenDependencyInfo(
+            Maven(
                 configuration = "testImplementation",
                 group = "org.mockito",
                 name = "mockito-core",
                 version = "4.8.0",
             ),
-            MavenDependencyInfo(
+            Maven(
                 configuration = "testImplementation",
                 group = "org.junit",
                 name = "junit",
@@ -171,7 +162,7 @@ class DependencyProcessorTest {
         val parser = createDependenciesParser()
         val dependency = createExternalDependency("libs.junit")
         val dependencies = listOf(
-            NotationDependencyInfo(
+            Notation(
                 DependencyType.NOTATION,
                 "implementation",
                 "libs.junit"
@@ -198,11 +189,11 @@ class DependencyProcessorTest {
             )
         }
         val dependencies = listOf(
-            FilesDependencyInfo(
+            Files(
                 "implementation",
                 listOf("local.jar")
             ),
-            FilesDependencyInfo(
+            Files(
                 "implementation",
                 listOf("some.jar", "something.else", "final.one")
             )
@@ -221,17 +212,17 @@ class DependencyProcessorTest {
         val parser = createDependenciesParser()
 
         val dependencies = listOf(
-            NotationDependencyInfo(
+            Notation(
                 type = DependencyType.PROJECT,
                 configuration = "implementation",
                 notation = ":lib1"
             ),
-            NotationDependencyInfo(
+            Notation(
                 type = DependencyType.PROJECT,
                 configuration = "implementation",
                 notation = ":lib2"
             ),
-            NotationDependencyInfo(
+            Notation(
                 type = DependencyType.PROJECT,
                 configuration = "implementation",
                 notation = ":lib3"

--- a/impl/src/test/kotlin/com/android/declarative/internal/configurators/RepositoriesConfiguratorTest.kt
+++ b/impl/src/test/kotlin/com/android/declarative/internal/configurators/RepositoriesConfiguratorTest.kt
@@ -1,0 +1,102 @@
+package com.android.declarative.internal.configurators
+
+import com.android.declarative.internal.IssueLogger
+import com.android.declarative.internal.model.PreDefinedRepositoryInfo
+import com.android.declarative.internal.model.RepositoryInfo
+import com.android.declarative.internal.model.RepositoryType
+import com.android.utils.ILogger
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.MockitoJUnit
+import org.mockito.junit.MockitoRule
+import org.mockito.quality.Strictness
+
+class RepositoriesConfiguratorTest {
+
+    @get:Rule
+    val rule: MockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS)
+
+    @Mock
+    lateinit var repositoryHandler: RepositoryHandler
+
+    @Mock
+    lateinit var logger: ILogger
+
+    private val issueLogger by lazy { IssueLogger(false, logger) }
+
+    @Test
+    fun testGoogle() {
+        RepositoriesConfigurator(issueLogger).apply(
+            "test",
+            repositoryHandler,
+            listOf(PreDefinedRepositoryInfo("google"))
+        )
+
+        Mockito.verify(repositoryHandler).google()
+        Mockito.verifyNoMoreInteractions(repositoryHandler)
+    }
+
+    @Test
+    fun testMavenCentral() {
+        RepositoriesConfigurator(issueLogger).apply(
+            "test",
+            repositoryHandler,
+            listOf(PreDefinedRepositoryInfo("mavenCentral"))
+        )
+
+        Mockito.verify(repositoryHandler).mavenCentral()
+        Mockito.verifyNoMoreInteractions(repositoryHandler)
+    }
+
+    @Test
+    fun testMavenLocal() {
+        RepositoriesConfigurator(issueLogger).apply(
+            "test",
+            repositoryHandler,
+            listOf(PreDefinedRepositoryInfo("mavenLocal"))
+        )
+
+        Mockito.verify(repositoryHandler).mavenLocal()
+        Mockito.verifyNoMoreInteractions(repositoryHandler)
+    }
+
+    @Test
+    fun testGradlePluginPortal() {
+        RepositoriesConfigurator(issueLogger).apply(
+            "test",
+            repositoryHandler,
+            listOf(PreDefinedRepositoryInfo("gradlePluginPortal"))
+        )
+
+        Mockito.verify(repositoryHandler).gradlePluginPortal()
+        Mockito.verifyNoMoreInteractions(repositoryHandler)
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun testUnknownNamed() {
+        RepositoriesConfigurator(issueLogger).apply(
+            "test",
+            repositoryHandler,
+            listOf(PreDefinedRepositoryInfo("unknown"))
+        )
+
+        Mockito.verifyNoInteractions(repositoryHandler)
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun testUnknownRepositoryInfo() {
+        val repositoryInfo = object: RepositoryInfo {
+            override val type: RepositoryType = RepositoryType.PRE_DEFINED
+        }
+        RepositoriesConfigurator(issueLogger).apply(
+            "test",
+            repositoryHandler,
+            listOf(repositoryInfo)
+        )
+
+        Mockito.verifyNoInteractions(repositoryHandler)
+    }
+}

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/build.gradle.toml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/app/build.gradle.toml
@@ -10,4 +10,7 @@ namespace = "com.example.app"
 [android.defaultConfig]
 minSdk = 21
 
-[dependencies.implementation.lib]
+[dependencies]
+implementation = [
+    { project = ":lib" }
+]

--- a/tests/src/test-projects/nestedBuildScriptSingleLibApplication/settings.gradle.toml
+++ b/tests/src/test-projects/nestedBuildScriptSingleLibApplication/settings.gradle.toml
@@ -1,7 +1,5 @@
 include = [ ":app", ":lib" ]
 
-[[pluginsManagement.repositories.inheritSettings]]
-
 [[plugins]]
 module = "com.android.tools.build:gradle"
 version = "8.3.0-dev"

--- a/tests/src/test-projects/singleLibApplication/app/build.gradle.toml
+++ b/tests/src/test-projects/singleLibApplication/app/build.gradle.toml
@@ -8,4 +8,7 @@ namespace = "com.example.app"
 [android.defaultConfig]
 minSdk = 21
 
-[dependencies.implementation.lib]
+[dependencies]
+implementation = [
+    { project = ":lib" }
+]

--- a/tests/src/test-projects/singleLibApplication/settings.gradle.toml
+++ b/tests/src/test-projects/singleLibApplication/settings.gradle.toml
@@ -1,6 +1,7 @@
 include = [ ":app", ":lib" ]
 
-[[pluginsManagement.repositories.inheritSettings]]
+[pluginManagement.repositories]
+inheritSettings = true
 
 [[plugins]]
 module = "com.android.tools.build:gradle"

--- a/tests/src/test/kotlin/com/android/declarative/tests/JavaLibraryDeclarativeTest.kt
+++ b/tests/src/test/kotlin/com/android/declarative/tests/JavaLibraryDeclarativeTest.kt
@@ -83,7 +83,10 @@ class JavaLibraryDeclarativeTest {
             [android.defaultConfig]
             minSdk = 21
 
-            [dependencies.implementation.javaLib]
+            [dependencies]
+            implementation = [
+                { project = ":javaLib" }, 
+            ]
         """.trimIndent())
         app.buildFile.writeText(
             """

--- a/tests/src/test/kotlin/com/android/declarative/tests/LargeDeclarativeTest.kt
+++ b/tests/src/test/kotlin/com/android/declarative/tests/LargeDeclarativeTest.kt
@@ -80,6 +80,9 @@ class LargeDeclarativeTest {
                         [android.defaultConfig]
                         minSdk = 21
 
+                        [dependencies]
+                        implementation = [
+                        
                         """.trimIndent()
                     )
                     val alreadyAllocated = mutableListOf<Int>()
@@ -89,7 +92,7 @@ class LargeDeclarativeTest {
                             nextIndex = random.nextInt(nbOfAndroidLibs)
                         }
                         alreadyAllocated.add(nextIndex)
-                        builder.append("[dependencies.implementation.lib$nextIndex]\n")
+                        builder.append("    { project = \":lib$nextIndex\" },\n")
                     }
                     alreadyAllocated.clear()
                     repeat(nbOfJavaLibsDependenciesPerApp) { _ ->
@@ -98,8 +101,9 @@ class LargeDeclarativeTest {
                             nextIndex = random.nextInt(nbOfJavaLibs)
                         }
                         alreadyAllocated.add(nextIndex)
-                        builder.append("[dependencies.implementation.javaLib$nextIndex]\n")
+                        builder.append("    { project = \":javaLib$nextIndex\" },\n")
                     }
+                    builder.append("]\n")
                 }.toString()
             )
             app.buildFile.delete()
@@ -120,6 +124,8 @@ class LargeDeclarativeTest {
                         [android.defaultConfig]
                         minSdk = 21
 
+                        [dependencies]
+                        implementation = [
                         """.trimIndent())
                     val alreadyAllocated = mutableListOf<Int>()
                     repeat(nbOfJavaLibsDependenciesPerAndroidLib) { _ ->
@@ -128,8 +134,9 @@ class LargeDeclarativeTest {
                             nextIndex = random.nextInt(nbOfJavaLibs)
                         }
                         alreadyAllocated.add(nextIndex)
-                        builder.append("[dependencies.implementation.javaLib$nextIndex]\n")
+                        builder.append("    { project = \":javaLib$nextIndex\" },\n")
                     }
+                    builder.append("]\n")
                 }.toString()
             )
             androidLib.buildFile.delete()
@@ -179,12 +186,12 @@ class LargeDeclarativeTest {
                 [[plugins]]
                 id = "com.android.application"
                 module = "com.android.tools.build:gradle" 
-                version = "8.0.0"
+                version = "8.3.0-dev"
 
                 [[plugins]]
                 id = "com.android.library"
                 module = "com.android.tools.build:gradle" 
-                version = "8.0.0"
+                version = "8.3.0-dev"
 
                 [include]
 

--- a/tests/src/test/kotlin/com/android/declarative/tests/SettingsDeclaredPluginTest.kt
+++ b/tests/src/test/kotlin/com/android/declarative/tests/SettingsDeclaredPluginTest.kt
@@ -53,7 +53,9 @@ class SettingsDeclaredPluginTest {
             minSdk = 21
 
             [dependencies]
-            javalib = { configuration = "implementation", project = ":javaLib" }
+            implementation = [
+                { project = ":javaLib" }
+            ]
         """.trimIndent())
 
         JavaLibraryDeclarativeTest.initJavaLib(project, false)
@@ -84,9 +86,9 @@ plugins {
             [[plugins]]
             id = "com.android.application"
             module = "com.android.tools.build:gradle" 
-            version = "7.4.0"
+            version = "8.3.0-dev"
 
-            [include]
+            [includes]
             app = ":app"
             javaLib = ":javaLib"
 

--- a/tests/src/test/kotlin/com/android/declarative/tests/SingleLibraryDeclarativeTest.kt
+++ b/tests/src/test/kotlin/com/android/declarative/tests/SingleLibraryDeclarativeTest.kt
@@ -43,7 +43,10 @@ class SingleLibraryDeclarativeTest {
             [android.defaultConfig]
             minSdk = 21
 
-            [dependencies.implementation.lib]
+            [dependencies]
+            implementation = [
+                { project = ":lib" } 
+            ]
         """.trimIndent())
         app.buildFile.writeText(
             """


### PR DESCRIPTION
removed inheritSettings as it is not useful, all pluginManagement repositories must always be inherited.

remove support for command line focus as it is not different from configure on demand (and has the same limitations). adapted existing tests.

Test: unit tests.