### PR TITLE
fix plugin loading for included build-logic.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.8.10"
+kotlin = "1.9.20-Beta"
 tomlj = "1.1.0"
 junit = "4.13.2"
 plugin-publish = "1.0.0"

--- a/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
@@ -41,19 +41,7 @@ class DeclarativePlugin @Inject constructor(
         val cache = DslTypesCache()
         parseDeclarativeBuildFile(project, issueLogger, project.layout.projectDirectory.file(buildFileName), cache)
 
-        // this is a hack until https://github.com/gradle/gradle/issues/22468 is fixed.
-        // remove installed extensions
-        val mapOfExtensions = project.extensions.javaClass.getDeclaredField("extensionsStorage").let {
-            it.isAccessible = true
-            it.get(project.extensions)
-        }.let { extensions ->
-            extensions.javaClass.getDeclaredField("extensions").let {
-                it.isAccessible = true
-                it.get(extensions)
-            }
-        } as MutableMap<*, *>
-        mapOfExtensions.remove("libs")
-        mapOfExtensions.remove("versionCatalogs")
+        GradleIssuesWorkarounds.removeVersionCatalogSupport(project)
 
         project.afterEvaluate {
             createTasks(it)

--- a/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/DeclarativePlugin.kt
@@ -41,6 +41,19 @@ class DeclarativePlugin @Inject constructor(
         val cache = DslTypesCache()
         parseDeclarativeBuildFile(project, issueLogger, project.layout.projectDirectory.file(buildFileName), cache)
 
+        // this is a hack until https://github.com/gradle/gradle/issues/22468 is fixed.
+        // remove installed extensions
+        val mapOfExtensions = project.extensions.javaClass.getDeclaredField("extensionsStorage").let {
+            it.isAccessible = true
+            it.get(project.extensions)
+        }.let { extensions ->
+            extensions.javaClass.getDeclaredField("extensions").let {
+                it.isAccessible = true
+                it.get(extensions)
+            }
+        } as MutableMap<*, *>
+        mapOfExtensions.remove("libs")
+        mapOfExtensions.remove("versionCatalogs")
 
         project.afterEvaluate {
             createTasks(it)
@@ -70,8 +83,8 @@ class DeclarativePlugin @Inject constructor(
         // plugins must be applied first so extensions are correctly registered.
         parsedDecl.getArray("plugins")?.also { plugins ->
             PluginParser().parse(plugins).forEach { pluginInfo ->
-                println("In project, applying ${pluginInfo.id}")
-                project.pluginManager.apply(pluginInfo.id)
+                issueLogger.logger.quiet("In ${project.path} , applying ${pluginInfo.id}")
+                project.plugins.apply(pluginInfo.id)
             }
         }
 
@@ -79,21 +92,24 @@ class DeclarativePlugin @Inject constructor(
             val buildFileCount = it.size()
             for (index in 0 until buildFileCount) {
                 val includedBuildFile = project.layout.projectDirectory.file(it.getString(index))
-                parseDeclarativeBuildFile(project, issueLogger,  includedBuildFile, cache)
+                parseDeclarativeBuildFile(project, issueLogger, includedBuildFile, cache)
             }
         }
 
         parsedDecl.keySet().forEach { topLevelDeclaration ->
-            when(topLevelDeclaration) {
+            when (topLevelDeclaration) {
                 "includeBuildFiles" -> {
                     // skip includes processing again.
                 }
+
                 "plugins" -> {
                     // already applied above.
                 }
+
                 "dependencies" -> {
                     // handled below, so all DSL driven configurations are created before dependencies are added.
                 }
+
                 "androidComponents" -> {
                     // androidComponents is handled separately with a dedicated parser since it is very
                     // heavy on callbacks which cannot be generically parsed.
@@ -106,6 +122,7 @@ class DeclarativePlugin @Inject constructor(
                         issueLogger
                     )
                 }
+
                 else -> {
                     parseTomlTable(
                         GenericDeclarativeParser(project, cache, issueLogger),

--- a/impl/src/main/kotlin/com/android/declarative/internal/GradleIssuesWorkarounds.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/GradleIssuesWorkarounds.kt
@@ -1,0 +1,47 @@
+package com.android.declarative.internal
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
+class GradleIssuesWorkarounds {
+    companion object {
+
+        /**
+         * This is a hack until https://github.com/gradle/gradle/issues/22468 is fixed.
+         * we basically steal the versionCatalogs extension from the root project and store them
+         * in the sub project's extensions. In turn the Project's DeclarativePlugin will remove those
+         * so it can be reinserted by Gradle when it is ready to do so.
+         */
+        fun installVersionCatalogSupport(project: Project) {
+
+            project.rootProject.extensions.findByName("libs")?.let {
+                project.extensions.add("libs", it)
+            }
+            project.rootProject.extensions.findByType(VersionCatalogsExtension::class.java)?.let {
+                project.extensions.add("versionCatalogs", it)
+            }
+        }
+
+        /**
+         * this is a hack until https://github.com/gradle/gradle/issues/22468 is fixed.
+         *
+         * Counterpart to the [installVersionCatalogSupport] method, where all extensions added are removed. This is
+         * necessary as Gradle will eventually try to register those extensions and would fail if they are already
+         * present in the extensions contains.
+         */
+        fun removeVersionCatalogSupport(project: Project) {
+
+            val mapOfExtensions = project.extensions.javaClass.getDeclaredField("extensionsStorage").let {
+                it.isAccessible = true
+                it.get(project.extensions)
+            }.let { extensions ->
+                extensions.javaClass.getDeclaredField("extensions").let {
+                    it.isAccessible = true
+                    it.get(extensions)
+                }
+            } as MutableMap<*, *>
+            mapOfExtensions.remove("libs")
+            mapOfExtensions.remove("versionCatalogs")
+        }
+    }
+}

--- a/impl/src/main/kotlin/com/android/declarative/internal/SettingsDeclarativePlugin.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/SettingsDeclarativePlugin.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.initialization.Settings
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.internal.time.Time
@@ -222,16 +221,7 @@ class SettingsDeclarativePlugin @Inject constructor(
         // only registers the declarative plugin if there is a build.gradle.toml file present in the project dir.
         if (projectDeclarativeFile.isPresent) {
 
-            // this is a hack until https://github.com/gradle/gradle/issues/22468 is fixed.
-            // we basically steal the versionCatalogs extension from the root project and store them
-            // in the sub project's extensions. In turn the Project's DeclarativePlugin will remove those
-            // so it can be reinserted by Gradle when it is ready to do so.
-            project.rootProject.extensions.findByName("libs")?.let {
-                project.extensions.add("libs", it)
-            }
-            project.rootProject.extensions.findByType(VersionCatalogsExtension::class.java)?.let {
-                project.extensions.add("versionCatalogs", it)
-            }
+            GradleIssuesWorkarounds.installVersionCatalogSupport(project)
 
             // apply declarative plugin last as it will immediately apply the project's declared plugins which
             // are probably added to the classpath right above.

--- a/impl/src/main/kotlin/com/android/declarative/internal/configurators/IncludedBuildPluginCache.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/configurators/IncludedBuildPluginCache.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.declarative.internal.configurators
+
+import org.gradle.api.Project
+import java.io.File
+import java.util.Properties
+
+class IncludedBuildPluginInfo(
+    val classesDir: File,
+    val resourcesDir: File,
+)
+
+class IncludedBuildPluginCache(
+    private val project: Project,
+    private val includedBuildDir: File,
+) {
+    private val markerFileLookup = "**/META-INF/gradle-plugins/*.properties"
+
+    private val markerFiles: Set<File> =
+        project.fileTree(includedBuildDir) {
+            it.include(markerFileLookup)
+        }.files
+
+
+    fun getPluginClassPath(): Set<File> =
+        mutableSetOf<File>().also { allFolders ->
+            markerFiles.forEach { markerFile ->
+                getBinaryFolders(markerFile).let {
+                    allFolders.add(it.first)
+                    allFolders.add(it.second)
+                }
+            }
+        }
+
+
+    fun resolvePluginById(id:String): IncludedBuildPluginInfo? {
+        markerFiles.firstOrNull {
+            it.name == "$id.properties"
+        }?.let { markerFile ->
+            loadPluginMarkerFile(markerFile)?.let { implementationClassName ->
+
+                val classFile = project.fileTree(includedBuildDir) {
+                    it.include("**/$implementationClassName.class")
+                }
+
+                val resourcesDir = markerFile.parentFile.parentFile.parentFile
+
+                val classesDir = classFile.singleFile.absolutePath.substring(0,
+                    classFile.singleFile.absolutePath.length -
+                            (implementationClassName.length + ".class".length + File.separator.length)
+                )
+
+                return IncludedBuildPluginInfo(File(classesDir), resourcesDir)
+            }
+        }
+        return null
+    }
+
+    private fun getBinaryFolders(markerFile: File): Pair<File, File> {
+        loadPluginMarkerFile(markerFile).let { implementationClassName ->
+
+            val classFile = project.fileTree(includedBuildDir) {
+                it.include("**/$implementationClassName.class")
+            }
+
+            val resourcesDir = markerFile.parentFile.parentFile.parentFile
+
+            val classesDir = classFile.singleFile.absolutePath.substring(
+                0,
+                classFile.singleFile.absolutePath.length -
+                        (implementationClassName.length + ".class".length + File.separator.length)
+            )
+            return File(classesDir) to resourcesDir
+        }
+
+    }
+    private fun loadPluginMarkerFile(markerFile: File): String =
+        Properties().also {
+            it.load(markerFile.reader())
+        }.getProperty("implementation-class")
+}

--- a/impl/src/main/kotlin/com/android/declarative/internal/variantApi/AndroidComponentsParser.kt
+++ b/impl/src/main/kotlin/com/android/declarative/internal/variantApi/AndroidComponentsParser.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.android.declarative.internal.variantApi
 
 import com.android.build.api.variant.AndroidComponentsExtension
@@ -25,7 +40,7 @@ class AndroidComponentsParser(
     private val issueLogger: IssueLogger = IssueLogger(false, LoggerWrapper(project.logger)),
 ): DeclarativeFileParser {
 
-    override fun <T: Any> parse(table: TomlTable, type: KClass<out T>, extension: T) {
+    override fun <T : Any> parse(table: TomlTable, type: KClass<out T>, extension: T) {
         // the extension is a subclass of AndroidComponentsExtension, its type parameters will tell me
         // type types of the VariantBuilder and Variant object I am dealing with.
         val superType = type.supertypes.first { superType ->


### PR DESCRIPTION
Had to work around two gradle issues :
https://github.com/gradle/gradle/issues/22468
https://github.com/gradle/gradle/issues/26435

force initialization of the version control by temporarily taking the one from the root project (and removing it once done).

added build-logic binary folders to the buildscript classpath for project so plugins are discovered successfully

Test: manually with NowInAndroid app.